### PR TITLE
include fathom tracking (enable only in production build)

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "scripts": {
     "dev": "webpack-dev-server --host 0.0.0.0 --port 1234 --mode development ",
-    "build": "webpack --mode production"
+    "build": "NODE_ENV=production webpack --mode production"
   },
   "dependencies": {
     "deck.gl": "^7.2.3",

--- a/src/index.html
+++ b/src/index.html
@@ -13,6 +13,19 @@
 
 <body>
     <div id="root"></div>
+    <script>
+        (function(f, a, t, h, o, m){
+            a[h]=a[h]||function(){
+                (a[h].q=a[h].q||[]).push(arguments)
+            };
+            o=f.createElement('script'),
+            m=f.getElementsByTagName('script')[0];
+            o.async=1; o.src=t; o.id='fathom-script';
+            m.parentNode.insertBefore(o,m)
+        })(document, window, '//fathom.codeformuenster.org/tracker.js', 'fathom');
+        fathom('set', 'siteId', '<%= FathomSiteId %>');
+        fathom('trackPageview');
+    </script>
 </body>
 
 </html>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,7 +5,10 @@ const HtmlWebPackPlugin = require("html-webpack-plugin");
 
 const htmlPlugin = new HtmlWebPackPlugin({
     template: "./src/index.html",
-    filename: "./index.html"
+    filename: "./index.html",
+    templateParameters: {
+        'FathomSiteId': process.env.NODE_ENV === 'production' ? 'RGQFH' : ''
+    }
 });
 
 module.exports = {


### PR DESCRIPTION
Resolve #1 

Adds the fathom tracking snippet. Tracking is enabled through adding the site id through webpack when `NODE_ENV=production` is enabled.

Blocks #2 